### PR TITLE
fix UnicodeEncodeError and some formatting inconsistencies

### DIFF
--- a/interact_web.py
+++ b/interact_web.py
@@ -10,7 +10,7 @@ parser.add_argument("-debug", type=s2b, nargs='?', const=True, default=False,
                     help="debugging flag")
 args = parser.parse_args()
 
-history=[]
+history = []
 
 while True:
     inp = input('> ')

--- a/interact_web.py
+++ b/interact_web.py
@@ -13,12 +13,14 @@ args = parser.parse_args()
 history=[]
 
 while True:
-    inp=input('> ')
-    response = requests.post(args.url, data='{"inputs": ["Input: '+inp+' Context: ['+'<div>'.join(history)+']"]}')
-    message=json.loads(response.text.replace("⁇ ","<"))
-    if "error" in message or args.debug: print(f"\n{message}\n")
+    inp = input('> ')
+    inpdata = '{"inputs": ["Input: '+inp+' Context: ['+'<div>'.join(history)+']"]}'
+    response = requests.post(args.url.encode("utf-8"), data=inpdata.encode("utf-8"))
+    message = json.loads(response.text.replace("⁇ ","<"))
+    if "error" in message or args.debug: 
+        print(f"\n{message}\n")
     if not "error" in message: 
         print(message["outputs"]["outputs"][0].replace("<br>", "\n"))
         history.append(inp)
         history.append(message["outputs"]["outputs"][0])
-        history=history[-4:]
+        history = history[-4:]


### PR DESCRIPTION
The python script would occasionally throw a UnicodeEncodeError because the post request needed its arguments (or at least the data?) to be encoded in utf-8.  [Here's an issue](https://github.com/psf/requests/issues/1822) that discusses this problem/solution.

I also fixed a few formatting inconsistencies.  Also the [python style guide](https://www.python.org/dev/peps/pep-0008/) is pretty useful if you need it!